### PR TITLE
update to 1.17.0

### DIFF
--- a/provider/sls.go
+++ b/provider/sls.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
 	"go.opentelemetry.io/otel/metric/global"
-	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"os"
 	"strings"
 	"time"


### PR DESCRIPTION
因为版本不匹配，initMetric阶段会出现`detecting resources: [cannot merge resource due to conflicting Schema URL cannot merge resource due `错误。  
可通过以下代码复现
```go
package main

import (
	"github.com/aliyun-sls/opentelemetry-go-provider-sls/provider"
)

type ErrorHandler struct {
}

func (E ErrorHandler) Handle(err error) {
	panic(err)
}
func main() {

	slsConfig, err := provider.NewConfig(provider.WithServiceName("service"),
		provider.WithServiceNamespace("namespace"),
		provider.WithServiceVersion("0.1.0"),
		provider.WithTraceExporterEndpoint("stdout"),
		provider.WithMetricExporterEndpoint("stdout"),
		provider.WithErrorHandler(&ErrorHandler{}),
	)
	// 使用panic()，表示如果初始化失败则程序直接异常退出，您也可以使用其他错误处理方式。
	if err != nil {
		panic(err)
	}
	if err := provider.Start(slsConfig); err != nil {
		panic(err)
	}
}

```